### PR TITLE
Travis is reconfigured to use srclib from repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,11 @@ jdk:
   - oraclejdk8
 
 install:
-  # Install Srclib
-  - mkdir -p $HOME/bin
-  - export PATH=$PATH:$HOME/bin
-  - curl -Lo $HOME/bin/srclib.gz https://srclib-release.s3.amazonaws.com/srclib/0.1.1-no-docker5/linux-amd64/srclib.gz 
-  - gunzip -c $HOME/bin/srclib.gz > $HOME/bin/srclib
-  - sudo chmod +x $HOME/bin/srclib
+# installing srclib
+  - mkdir $HOME/gocode
+  - export GOPATH=$HOME/gocode
+  - go get -u -v sourcegraph.com/sourcegraph/srclib/cmd/srclib
+  - export PATH=$PATH:$HOME/gocode/bin
   # Build this toolchain
   - make
   - mkdir -p $HOME/.srclib/sourcegraph.com/sourcegraph


### PR DESCRIPTION
Travis is reconfigured to use srclib from repository (instead of installing predefined binary version)