### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/src/main/java/com/sourcegraph/javagraph/AndroidOriginResolver.java
+++ b/src/main/java/com/sourcegraph/javagraph/AndroidOriginResolver.java
@@ -36,6 +36,9 @@ public class AndroidOriginResolver {
         }
     }
 
+    private AndroidOriginResolver() {
+    }
+
     /**
      * Resolves jar URI either to libcore or to frameworks/base resolved target
      * @param origin URI to resolve

--- a/src/main/java/com/sourcegraph/javagraph/BuildAnalysis.java
+++ b/src/main/java/com/sourcegraph/javagraph/BuildAnalysis.java
@@ -24,6 +24,9 @@ public class BuildAnalysis {
 
     public static final String DEFAULT_GROUP_ID = "default-group";
 
+    private BuildAnalysis() {
+    }
+
     /**
      * POM attributes, holds group ID, artifact ID, and description
      */
@@ -188,6 +191,9 @@ public class BuildAnalysis {
         private static final String GRADLE_CMD_OTHER = "gradle";
 
         private static final String REPO_DIR = ".gradle-srclib";
+
+        private Gradle() {
+        }
 
         /**
          * Collects meta information from a gradle build file

--- a/src/main/java/com/sourcegraph/javagraph/JSONUtil.java
+++ b/src/main/java/com/sourcegraph/javagraph/JSONUtil.java
@@ -15,6 +15,9 @@ import java.nio.charset.StandardCharsets;
  */
 public class JSONUtil {
 
+    private JSONUtil() {
+    }
+
     /**
      * Writes object as UTF-8 JSON
      *

--- a/src/main/java/com/sourcegraph/javagraph/MavenCentralUtils.java
+++ b/src/main/java/com/sourcegraph/javagraph/MavenCentralUtils.java
@@ -24,6 +24,9 @@ public class MavenCentralUtils {
 
     private static final String BASE_URL = "http://search.maven.org/solrsearch";
 
+    private MavenCentralUtils() {
+    }
+
     public static RawDependency searchInCentral(Path jar) {
         try {
             return searchInCentral(calculateSha(jar));

--- a/src/main/java/com/sourcegraph/javagraph/Origins.java
+++ b/src/main/java/com/sourcegraph/javagraph/Origins.java
@@ -12,6 +12,9 @@ public class Origins {
 
     private static JavaFileObject lastElementObject;
 
+    private Origins() {
+    }
+
     /**
      * resolves java file object for a given java program element
      * @param e java program element

--- a/src/main/java/com/sourcegraph/javagraph/PathUtil.java
+++ b/src/main/java/com/sourcegraph/javagraph/PathUtil.java
@@ -17,6 +17,9 @@ public class PathUtil {
      */
     public static Path CWD = SystemUtils.getUserDir().toPath().toAbsolutePath().normalize();
 
+    private PathUtil() {
+    }
+
     /**
      * Normalizes path string by translating it to Unix-style (foo\bar => foo/bar)
      * @param path path to normalize

--- a/src/main/java/com/sourcegraph/javagraph/ScanUtil.java
+++ b/src/main/java/com/sourcegraph/javagraph/ScanUtil.java
@@ -18,6 +18,9 @@ public class ScanUtil {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ScanUtil.class);
 
+    private ScanUtil() {
+    }
+
     /**
      * Retrieves all matching files in current working directory
      * @param fileName file name to match against


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.