### PR TITLE
Properly evaluating toolchain's SHA hash in Docker mode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 jar {
-	def gitRef = "sh -c 'git rev-parse --short HEAD || echo snapshot'".execute().text.trim()
+	def gitRef = "sh -c 'git rev-parse --short HEAD || git ls-remote https://github.com/sourcegraph/srclib-java master | awk \"{ print \\\$1 }\" || echo snapshot'".execute().text.trim()
 
 	manifest {
 		attributes "Main-Class" : mainClassName


### PR DESCRIPTION
- When building toolchain in the Docker container, there is no .git data available and thus we cannot extract SHA to be included into manifest (in order to display it in logs). In this case using SHA obtained from https://github.com/sourcegraph/srclib-java repository