### PR TITLE
Improved Android support

### DIFF
--- a/src/main/java/com/sourcegraph/javagraph/DepresolveCommand.java
+++ b/src/main/java/com/sourcegraph/javagraph/DepresolveCommand.java
@@ -64,7 +64,7 @@ public class DepresolveCommand {
             } else if (AndroidSDKProject.is(unit)) {
                 // only Android Core
                 resolutions.add(new DepResolution(null, ResolvedTarget.androidCore()));
-            } else if (unit.Data.containsKey("Android")) {
+            } else if (unit.Data.containsKey(SourceUnit.ANDROID_MARKER)) {
                 resolutions.add(new DepResolution(null, ResolvedTarget.androidCore()));
                 resolutions.add(new DepResolution(null, ResolvedTarget.androidSDK()));
             } else {

--- a/src/main/java/com/sourcegraph/javagraph/GradleProject.java
+++ b/src/main/java/com/sourcegraph/javagraph/GradleProject.java
@@ -186,7 +186,7 @@ public class GradleProject implements Project {
             }
 
             if (info.androidSdk != null) {
-                unit.Data.put("Android", info.androidSdk);
+                unit.Data.put(SourceUnit.ANDROID_MARKER, info.androidSdk);
             }
 
             // leave only existing files

--- a/src/main/java/com/sourcegraph/javagraph/MavenProject.java
+++ b/src/main/java/com/sourcegraph/javagraph/MavenProject.java
@@ -395,7 +395,7 @@ public class MavenProject implements Project {
             unit.Data.put("ClassPath", classPath);
             unit.Data.put("SourcePath", sourcePath);
             if (info.androidSdk != null) {
-                unit.Data.put("Android", true);
+                unit.Data.put(SourceUnit.ANDROID_MARKER, true);
             }
             ret.add(unit);
         }

--- a/src/main/java/com/sourcegraph/javagraph/Resolver.java
+++ b/src/main/java/com/sourcegraph/javagraph/Resolver.java
@@ -132,6 +132,9 @@ public class Resolver {
      */
     private ResolvedTarget processSpecialJar(URI origin, Path jarFile) {
         if (isJDK(jarFile)) {
+            if (unit.Data.containsKey(SourceUnit.ANDROID_MARKER)) {
+                return AndroidOriginResolver.resolve(origin);
+            }
             ResolvedTarget target = ResolvedTarget.jdk();
             resolvedOrigins.put(origin, target);
             return target;

--- a/src/main/java/com/sourcegraph/javagraph/SourceUnit.java
+++ b/src/main/java/com/sourcegraph/javagraph/SourceUnit.java
@@ -23,6 +23,11 @@ public class SourceUnit {
     public static final String DEFAULT_TYPE = "JavaArtifact";
 
     /**
+     * Android-based project indicator
+     */
+    public static final String ANDROID_MARKER = "Android";
+
+    /**
      * Source unit name
      */
     String Name;

--- a/src/main/java/com/sourcegraph/javagraph/maven/plugins/SimpligilityAndroidMavenPlugin.java
+++ b/src/main/java/com/sourcegraph/javagraph/maven/plugins/SimpligilityAndroidMavenPlugin.java
@@ -28,7 +28,7 @@ public class SimpligilityAndroidMavenPlugin extends AbstractMavenPlugin {
 
     @Override
     public boolean isStandard() {
-        return false;
+        return true;
     }
 
     /**


### PR DESCRIPTION
- Taking into account Android Maven (simpligility, jayway) plugin if declared in "pluginManagement" section, not only in "plugins" one
- When project is Android-based and definition's origin is rt.jar, using Android resolver to make defs refer to Android's libcore or base framework instead of OpenJDK
