### PR TITLE
Building github.com/elastic/elasticsearch

### DIFF
--- a/src/main/java/com/sourcegraph/javagraph/Resolver.java
+++ b/src/main/java/com/sourcegraph/javagraph/Resolver.java
@@ -239,7 +239,9 @@ public class Resolver {
                 Result result = new Result();
                 OverrideConfiguration overrideConfiguration = entry.getValue();
                 result.uri = m.replaceAll(overrideConfiguration.replacement);
-                result.unit = overrideConfiguration.unit;
+                if (overrideConfiguration.unit != null) {
+                    result.unit = m.replaceAll(overrideConfiguration.unit);
+                }
                 return result;
             }
         }

--- a/src/main/resources/resolver.properties
+++ b/src/main/resources/resolver.properties
@@ -22,3 +22,4 @@
 ^com\\.google\\.android/annotations=https://android.googlesource.com/platform/frameworks/base;AndroidSDK
 ^org\\.khronos/opengl-api=https://android.googlesource.com/platform/frameworks/base;AndroidSDK
 ^com\\.google\\.android/support-v4=https://android.googlesource.com/platform/frameworks/support;AndroidSupport
+^org\\.apache\\.lucene/lucene-(.+)=https://github.com/apache/lucene-solr;$1


### PR DESCRIPTION
- custom configuration for `org.apache.lucene/lucene-..` artifacts because their POM files point to placeholders that cannot be parsed by `srclib`, for example http://central.maven.org/maven2/org/apache/lucene/lucene-core/6.0.1/lucene-core-6.0.1.pom defines `scm.url` as `${vc-browse-base-url};f=${module-directory}`